### PR TITLE
Make map non-flashing

### DIFF
--- a/pygpsclient/map_frame.py
+++ b/pygpsclient/map_frame.py
@@ -86,11 +86,6 @@ class MapviewFrame(Frame):
         w, h = self.width, self.height
         resize_font = font.Font(size=min(int(w / 20), 14))
 
-        if self.__app.frm_settings.webmap:
-            static = False
-        else:
-            static = True
-
         if lat is None or lat == "" or lon is None or lon == "":
             self.reset_map_refresh()
             self.can_mapview.create_text(
@@ -102,7 +97,7 @@ class MapviewFrame(Frame):
             )
             return
 
-        if static:
+        if not self.__app.frm_settings.webmap:
             self._draw_static_map(lat, lon)
         else:
             if hacc is None or hacc == "":

--- a/pygpsclient/map_frame.py
+++ b/pygpsclient/map_frame.py
@@ -92,15 +92,7 @@ class MapviewFrame(Frame):
             static = True
 
         if lat is None or lat == "" or lon is None or lon == "":
-            self.can_mapview.delete("all")
             self.reset_map_refresh()
-            self.can_mapview.create_text(
-                w / 2,
-                h / 2 - (w / 20),
-                text=NOWEBMAPERROR1,
-                fill="red",
-                font=resize_font,
-            )
             self.can_mapview.create_text(
                 w / 2,
                 h / 2 + (w / 20),


### PR DESCRIPTION
Hi, 

when one does not have a position fix the map will flash once a second and be replaced by a white field w/ the error messages 
"Map not available" and "No satellite fix.". For me this is a bit distracting/painful for the eyes so I checked what can be done about this. 
I hope this is not too intrusive to open this PR without asking first, I am happy to change things again or you can reject it :-)

My suggestion is: keep the map in the background, let only the warning flash (could o.c. also be constant, but I didn't know how to do that properly).
I also removed the first warning, because it seems a bit off in the conditional case where only the lon/lat is checked.

A picture how the error + map looks with the modification:
![map](https://user-images.githubusercontent.com/29774930/111662605-5c0ad480-8810-11eb-957f-3cb8a3d7f4dc.png)


In a second commit I combined two if clauses. The first only determined if static or map mode was selected and the second then executed it. I think it is cleaner to read if the check is directly on the conditional variable. That is of course a question of personal taste, therefore I commited it separately so it can be removed more easily.

I tested it with two receivers with and without fixes, incl. switching between them. I did not however test it with a webmap.

Best regards,
Malte
