### PR TITLE
Fix serial handler race condition Fixes #9

### DIFF
--- a/pygpsclient/globals.py
+++ b/pygpsclient/globals.py
@@ -85,6 +85,8 @@ KNOWNGPS = (
 )
 # list of available bps rates (first entry in list is the default):
 BPSRATES = (9600, 19200, 38400, 57600, 115200, 230400, 460800, 921600, 4800)
+# terminator for NMEA protocol
+CRLF = b"\x0d\x0a"
 # display formats
 FORMAT_PARSED = 1
 FORMAT_BIN = 2

--- a/pygpsclient/serial_handler.py
+++ b/pygpsclient/serial_handler.py
@@ -26,6 +26,8 @@ from pygpsclient.globals import (
 )
 from pygpsclient.strings import NOTCONN, SEROPENERROR, ENDOFFILE
 
+LOGGING = logging.WARNING
+
 
 class SerialHandler:
     """
@@ -49,6 +51,11 @@ class SerialHandler:
         self._file_thread = None
         self._connected = False
         self._reading = False
+
+        logging.basicConfig(
+            format="%(asctime)-15s [%(levelname)s] %(funcName)s: %(message)s",
+            level=LOGGING,
+        )
 
     def __del__(self):
         """
@@ -371,7 +378,7 @@ class SerialHandler:
             else:
                 parsing = False
 
-        # print(f"DEBUG UBXReader._parse_data r:{raw_data} p:{parsed_data}")
+        logging.debug(f"raw:{raw_data} parsed:{parsed_data}")
         if raw_data is None or parsed_data is None:
             return
         msgprot = protocol(raw_data)

--- a/pygpsclient/serial_handler.py
+++ b/pygpsclient/serial_handler.py
@@ -337,7 +337,7 @@ class SerialHandler:
         protfilter = self.__app.frm_settings.protocol
 
         try:
-            while parsing:
+            while parsing:  # loop until end of valid UBX/NMEA message or EOF
                 byte1 = stream.read(1)  # read first byte to determine protocol
                 if len(byte1) < 1:
                     raise EOFError
@@ -367,7 +367,7 @@ class SerialHandler:
                     raw_data = bytehdr + clsid + msgid + lenb + plb + cksum
                     parsed_data = UBXReader.parse(raw_data)
                     parsing = False
-                # if it's an NMEA message ('$G' or '$P')
+                # if it's an NMEA GNSS message ('$G' or '$P')
                 elif bytehdr in ubt.NMEA_HDR:
                     byten = stream.readline()
                     if byten[-2:] != CRLF:

--- a/pygpsclient/serial_handler.py
+++ b/pygpsclient/serial_handler.py
@@ -11,19 +11,20 @@ Created on 16 Sep 2020
 :license: BSD 3-Clause
 """
 
+import logging
 from io import BufferedReader
 from threading import Thread
 from serial import Serial, SerialException, SerialTimeoutException
-from pyubx2 import UBXReader, UBXParseError, protocol
-from pynmeagps import NMEAParseError
+from pynmeagps import NMEAReader
+from pyubx2 import UBXReader, protocol
 import pyubx2.ubxtypes_core as ubt
 from pygpsclient.globals import (
     CONNECTED,
     CONNECTED_FILE,
     DISCONNECTED,
-    QUITONERRORDEFAULT,
+    CRLF,
 )
-from pygpsclient.strings import NOTCONN, SEROPENERROR, FILEOPENERROR, ENDOFFILE
+from pygpsclient.strings import NOTCONN, SEROPENERROR, ENDOFFILE
 
 
 class SerialHandler:
@@ -47,7 +48,6 @@ class SerialHandler:
         self._serial_thread = None
         self._file_thread = None
         self._connected = False
-        self._reader = None
         self._reading = False
 
     def __del__(self):
@@ -70,7 +70,6 @@ class SerialHandler:
             return
 
         try:
-
             self._serial_object = Serial(
                 serial_settings.port,
                 serial_settings.bpsrate,
@@ -82,11 +81,24 @@ class SerialHandler:
                 timeout=serial_settings.timeout,
             )
             self._serial_buffer = BufferedReader(self._serial_object)
-            msg = (
-                f"{serial_settings.port}:{serial_settings.port_desc}"
-                + f"@ {str(serial_settings.bpsrate)}"
+            self.__app.frm_banner.update_conn_status(CONNECTED)
+            self.__app.set_connection(
+                (
+                    f"{serial_settings.port}:{serial_settings.port_desc} "
+                    + f"@ {str(serial_settings.bpsrate)}"
+                ),
+                "green",
             )
-            self.connect_stream(self._serial_buffer, CONNECTED, msg)
+            self.__app.frm_settings.enable_controls(CONNECTED)
+            self._connected = True
+            self.start_read_thread()
+
+            if self.__app.frm_settings.datalogging:
+                self.__app.file_handler.open_logfile()
+
+            if self.__app.frm_settings.record_track:
+                self.__app.file_handler.open_trackfile()
+            self.__app.set_status("Connected", "blue")
 
         except (IOError, SerialException, SerialTimeoutException) as err:
             self._connected = False
@@ -111,46 +123,26 @@ class SerialHandler:
             return
 
         try:
-
             self._serial_object = open(in_filepath, "rb")
             self._serial_buffer = BufferedReader(self._serial_object)
-            msg = f"{in_filepath}"
-            self.connect_stream(self._serial_buffer, CONNECTED_FILE, msg)
+            self.__app.frm_banner.update_conn_status(CONNECTED_FILE)
+            self.__app.set_connection(f"{in_filepath}", "blue")
+            self.__app.frm_settings.enable_controls(CONNECTED_FILE)
+            self._connected = True
+            self.start_readfile_thread()
+
+            if self.__app.frm_settings.datalogging:
+                self.__app.file_handler.open_logfile()
+
+            if self.__app.frm_settings.record_track:
+                self.__app.file_handler.open_trackfile()
 
         except (IOError, SerialException, SerialTimeoutException) as err:
             self._connected = False
             self.__app.set_connection(f"{in_filepath}", "red")
-            self.__app.set_status(FILEOPENERROR.format(err), "red")
+            self.__app.set_status(SEROPENERROR.format(err), "red")
             self.__app.frm_banner.update_conn_status(DISCONNECTED)
             self.__app.frm_settings.enable_controls(DISCONNECTED)
-
-    def connect_stream(self, stream: object, status: int, msg: str):
-        """
-        Instantiate UBXReader object and start the relevant
-        serial or file reader thread.
-
-        :param object stream: serial or file stream
-        :param str status: serial or file
-        :param str msg: connection descriptor message
-        """
-
-        self._reader = UBXReader(stream, quitonerror=QUITONERRORDEFAULT)
-
-        if self.__app.frm_settings.datalogging:
-            self.__app.file_handler.open_logfile()
-
-        if self.__app.frm_settings.record_track:
-            self.__app.file_handler.open_trackfile()
-
-        self.__app.set_status("Connected", "blue")
-        self.__app.frm_banner.update_conn_status(status)
-        self.__app.frm_settings.enable_controls(status)
-        self.__app.set_connection(msg, "green")
-        self._connected = True
-        if status == CONNECTED:  # serial
-            self.start_read_thread()
-        else:  # file
-            self.start_readfile_thread()
 
     def disconnect(self):
         """
@@ -160,7 +152,6 @@ class SerialHandler:
         if self._connected:
             try:
                 self._reading = False
-                self._reader = None
                 self._serial_object.close()
                 self.__app.frm_banner.update_conn_status(DISCONNECTED)
                 self.__app.set_connection(NOTCONN, "red")
@@ -179,56 +170,41 @@ class SerialHandler:
         self.__app.frm_settings.enable_controls(self._connected)
 
     @property
-    def port(self) -> str:
+    def port(self):
         """
         Getter for port
-
-        :return: port descriptor
-        :rtype: str
         """
 
         return self.__app.frm_settings.serial_settings().port
 
     @property
-    def connected(self) -> int:
+    def connected(self):
         """
         Getter for connection status
-
-        :return: connection status flag
-        :rtype: int
         """
 
         return self._connected
 
     @property
-    def serial(self) -> object:
+    def serial(self):
         """
         Getter for serial object
-
-        :return: serial object
-        :rtype: object
         """
 
         return self._serial_object
 
     @property
-    def buffer(self) -> object:
+    def buffer(self):
         """
         Getter for serial buffer
-
-        :return: serial buffer object
-        :rtype: object
         """
 
         return self._serial_buffer
 
     @property
-    def thread(self) -> object:
+    def thread(self):
         """
         Getter for serial thread
-
-        :return: serial reader thread
-        :rtype: object
         """
 
         return self._serial_thread
@@ -253,7 +229,7 @@ class SerialHandler:
         if self._connected:
             self._reading = True
             self.__app.frm_mapview.reset_map_refresh()
-            self._serial_thread = Thread(target=self._read_thread(), daemon=True)
+            self._serial_thread = Thread(target=self._read_thread, daemon=True)
             self._serial_thread.start()
 
     def start_readfile_thread(self):
@@ -264,7 +240,7 @@ class SerialHandler:
         if self._connected:
             self._reading = True
             self.__app.frm_mapview.reset_map_refresh()
-            self._file_thread = Thread(target=self._readfile_thread(), daemon=True)
+            self._file_thread = Thread(target=self._readfile_thread, daemon=True)
             self._file_thread.start()
 
     def stop_read_thread(self):
@@ -275,6 +251,7 @@ class SerialHandler:
         if self._serial_thread is not None:
             self._reading = False
             self._serial_thread = None
+            # self.__app.set_status(STOPDATA, "red")
 
     def stop_readfile_thread(self):
         """
@@ -284,6 +261,7 @@ class SerialHandler:
         if self._file_thread is not None:
             self._reading = False
             self._file_thread = None
+            # self.__app.set_status(STOPDATA, "red")
 
     def _read_thread(self):
         """
@@ -321,7 +299,7 @@ class SerialHandler:
 
         if self._reading and self._serial_object is not None:
             try:
-                self._parse_data()
+                self._parse_data(self._serial_buffer)
             except SerialException as err:
                 self.__app.set_status(f"Error {err}", "red")
 
@@ -335,28 +313,63 @@ class SerialHandler:
         self.disconnect()
         self.__app.set_status(ENDOFFILE, "blue")
 
-    def _parse_data(self):
+    def _parse_data(self, stream: object):
         """
-        Invoke the UBXReader.read() method to read and parse the data stream
-        and direct to the appropriate UBX and/or NMEA protocol handler,
-        depending on which protocols are filtered.
+        Read the binary data and direct to the appropriate
+        UBX and/or NMEA protocol handler, depending on which protocols
+        are filtered.
+
+        :param Serial ser: serial port
         """
 
+        parsing = True
         raw_data = None
         parsed_data = None
         protfilter = self.__app.frm_settings.protocol
 
-        try:
-            (raw_data, parsed_data) = self._reader.read()
-            if raw_data is None:
-                raise EOFError
-        except EOFError:
-            self.__master.event_generate("<<ubx_eof>>")
-            return
-        except (UBXParseError, NMEAParseError) as err:
-            # log errors to console, then continue
-            self.__app.frm_console.update_console(bytes(str(err), "utf-8"), err)
-            return
+        while parsing:
+            byte1 = stream.read(1)  # read first byte to determine protocol
+            if len(byte1) < 1:
+                self.__master.event_generate("<<ubx_eof>>")
+                return
+            if byte1 not in (b"\xb5", b"\x24"):  # not UBX or NMEA
+                continue
+            byte2 = stream.read(1)
+            if len(byte2) < 1:
+                self.__master.event_generate("<<ubx_eof>>")
+                return
+            # if it's a UBX message (b'\b5\x62')
+            bytehdr = byte1 + byte2
+            if bytehdr == ubt.UBX_HDR:
+                byten = stream.read(4)
+                if len(byten) < 4:
+                    self.__master.event_generate("<<ubx_eof>>")
+                    return
+                clsid = byten[0:1]
+                msgid = byten[1:2]
+                lenb = byten[2:4]
+                leni = int.from_bytes(lenb, "little", signed=False)
+                byten = stream.read(leni + 2)
+                if len(byten) < leni + 2:
+                    self.__master.event_generate("<<ubx_eof>>")
+                    return
+                plb = byten[0:leni]
+                cksum = byten[leni : leni + 2]
+                raw_data = bytehdr + clsid + msgid + lenb + plb + cksum
+                parsed_data = UBXReader.parse(raw_data)
+                parsing = False
+            # if it's an NMEA message ('$G' or '$P')
+            elif bytehdr in ubt.NMEA_HDR:
+                byten = stream.readline()
+                if byten[-2:] != CRLF:
+                    self.__master.event_generate("<<ubx_eof>>")
+                    return
+                raw_data = bytehdr + byten
+                parsed_data = NMEAReader.parse(raw_data)
+                parsing = False
+            # else drop it like it's hot
+            else:
+                parsing = False
 
         # print(f"DEBUG UBXReader._parse_data r:{raw_data} p:{parsed_data}")
         if raw_data is None or parsed_data is None:

--- a/pygpsclient/serial_handler.py
+++ b/pygpsclient/serial_handler.py
@@ -378,7 +378,7 @@ class SerialHandler:
             else:
                 parsing = False
 
-        logging.debug(f"raw:{raw_data} parsed:{parsed_data}")
+        logging.debug("raw: %s parsed: %s", raw_data, parsed_data)
         if raw_data is None or parsed_data is None:
             return
         msgprot = protocol(raw_data)

--- a/pygpsclient/serial_handler.py
+++ b/pygpsclient/serial_handler.py
@@ -71,6 +71,7 @@ class SerialHandler:
         """
         Open serial connection.
         """
+        # pylint: disable=consider-using-with
 
         serial_settings = self.__app.frm_settings.serial_settings()
         if serial_settings.status == 3:  # NOPORTS
@@ -124,6 +125,7 @@ class SerialHandler:
         """
         Open binary data file connection.
         """
+        # pylint: disable=consider-using-with
 
         in_filepath = self.__app.frm_settings.infilepath
         if in_filepath is None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pynmeagps>=1.0.7
+pynmeagps>=1.0.8
 requests>=2.24.0
 Pillow>=7.2.0
 pyserial>=3.4

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(exclude=["tests", "references", "images"]),
     install_requires=[
         "pyubx2>=1.2.4",
-        "pynmeagps>=1.0.7",
+        "pynmeagps>=1.0.8",
         "requests>=2.24.0",
         "Pillow>=7.2.0",
         "pyserial>=3.4",


### PR DESCRIPTION
# PyGPSClient Pull Request Template

## Description

Amend `serial_handler()` to avoid race condition on null data stream.

Fixes # (issue)

#9 

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py`
module or using your IDE's native Python unittest integration facilities.
Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] Tested on all platforms Windows, Linux, MacOS, RPiOS

## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
