### PR TITLE
Allow user-defined port Fixes #34

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ This is an independent project and we have no affiliation whatsoever with u-blox
 
 * To connect to a listed serial device, select the device from the listbox, set the appropriate serial connection parameters and click 
 ![connect icon](/pygpsclient/resources/usbport-1-24.png). The application will endeavour to pre-select a recognised GNSS/GPS device but this is platform and device dependent. Press the ![refresh](/pygpsclient/resources/iconmonstr-refresh-6-16.png) button to refresh the list of connected devices at any point. *Rate bps is typically the only setting that might need adjusting, but tweaking the timeout setting may improve performance on certain platforms*.
+* A default user-defined serial port can also be passed via the environment variable `PYGPSCLIENT_USERPORT` or as a command line keyword argument `port=/dev/tty12345`.
 * To connect to a TCP or UDP socket, enter the server URL and port, select the protocol (defaults to TCP) and click 
 ![connect socket icon](/pygpsclient/resources/ethernet-1-24.png).
 * To stream from a previously-saved binary datalog file, click 
@@ -212,6 +213,11 @@ deactivate
 To run the application, if the Python 3 scripts (bin) directory is in your PATH, simply type (all lowercase): 
 ```shell
 pygpsclient
+```
+
+Optionally, a user-defined serial port can be passed as a keyword argument, e.g.
+```shell
+pygpsclient port=/dev/tty12345
 ```
 
 If desired, you can add a shortcut to this command to your desktop or favourites menu.

--- a/docs/pygpsclient.rst
+++ b/docs/pygpsclient.rst
@@ -76,6 +76,14 @@ pygpsclient.helpers module
    :undoc-members:
    :show-inheritance:
 
+pygpsclient.helpstrings module
+------------------------------
+
+.. automodule:: pygpsclient.helpstrings
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 pygpsclient.map\_frame module
 -----------------------------
 

--- a/pygpsclient/__main__.py
+++ b/pygpsclient/__main__.py
@@ -10,16 +10,25 @@ Created on 12 Sep 2020
 
 import sys
 from tkinter import Tk
+from pygpsclient.helpstrings import PYGPSCLIENT_HELP
 from pygpsclient.app import App
 
 
 def main():
     """The main tkinter loop."""
 
+    if len(sys.argv) > 1:
+        if sys.argv[1] in {"-h", "--h", "help", "-help", "--help", "-H"}:
+            print(PYGPSCLIENT_HELP)
+            sys.exit()
+
+    kwargs = dict(arg.split("=") for arg in sys.argv[1:])
+
     root = Tk()
-    App(root)
+    App(root, **kwargs)
     root.mainloop()
+    sys.exit()
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/pygpsclient/app.py
+++ b/pygpsclient/app.py
@@ -12,7 +12,7 @@ Created on 12 Sep 2020
 :license: BSD 3-Clause
 """
 
-# import logging
+from os import getenv
 from threading import Thread
 from queue import Queue, Empty
 from datetime import datetime, timedelta
@@ -69,9 +69,6 @@ from pygpsclient.nmea_handler import NMEAHandler
 from pygpsclient.ubx_handler import UBXHandler
 
 
-# LOGGING = logging.INFO
-
-
 class App(Frame):  # pylint: disable=too-many-ancestors
     """
     Main PyGPSClient GUI Application Class
@@ -82,16 +79,15 @@ class App(Frame):  # pylint: disable=too-many-ancestors
         Set up main application and add frames
 
         :param tkinter.Tk master: reference to Tk root
-        :param args: optional args to pass to Frame parent class
-        :param kwargs: optional kwargs to pass to Frame parent class
+        :param args: optional args
+        :param kwargs: optional kwargs
         """
 
-        # logging.basicConfig(
-        #     format="%(asctime)-15s [%(levelname)s] %(funcName)s: %(message)s",
-        #     level=LOGGING,
-        # )
-
         self.__master = master
+
+        # user-defined serial port can be passed as environment variable
+        # or command line keyword argument
+        self._user_port = kwargs.pop("port", getenv("PYGPSCLIENT_USERPORT", ""))
 
         Frame.__init__(self, self.__master, *args, **kwargs)
 
@@ -319,6 +315,15 @@ class App(Frame):  # pylint: disable=too-many-ancestors
         else:
             self.frm_mapview.grid_forget()
             self.menu.view_menu.entryconfig(3, label=MENUSHOWMAP)
+
+    @property
+    def user_port(self) -> str:
+        """
+        Getter for user-defined port passed as optional
+        command line keyword argument.
+        """
+
+        return self._user_port
 
     @property
     def conn_status(self) -> int:

--- a/pygpsclient/helpstrings.py
+++ b/pygpsclient/helpstrings.py
@@ -1,0 +1,46 @@
+"""
+Help text strings for PyGPSClient command line keyword args
+Created on 31 Oct 2022
+:author: semuadmin
+:copyright: SEMU Consulting © 2022
+:license: BSD 3-Clause
+"""
+# pylint: disable=line-too-long
+
+from platform import system
+from pygpsclient._version import __version__ as VERSION
+
+# console escape sequences don't work on standard Windows terminal
+RED = ""
+GREEN = ""
+BLUE = ""
+YELLOW = ""
+MAGENTA = ""
+CYAN = ""
+BOLD = ""
+NORMAL = ""
+if system() != "Windows":
+    RED = "\033[31m"
+    GREEN = "\033[32m"
+    BLUE = "\033[34m"
+    YELLOW = "\033[33m"
+    MAGENTA = "\033[35m"
+    CYAN = "\033[36m"
+    BOLD = "\033[1m"
+    NORMAL = "\033[0m"
+
+
+PYGPSCLIENT_HELP = (
+    f"\n\n{RED}{BOLD}PyGPSClient v{VERSION}\n"
+    + f"=================={NORMAL}\n\n"
+    + f"{BOLD}PyGPSClient{NORMAL} is a multi-platform graphical "
+    + "GNSS/GPS testing, diagnostic and UBX © (u-blox ™) device configuration "
+    + "application written entirely in Python and tkinter. "
+    + "PyGPSClient is capable of parsing NMEA, UBX and RTCM3 protocols.\n\n"
+    + f"{GREEN}Usage:{NORMAL}\n\n"
+    + "  pygpsclient\n\n"
+    + f"{GREEN}Optional command line keyword arguments (default):{NORMAL}\n\n"
+    + "  port - user defined serial port (None)\n\n"
+    + f"{CYAN}© 2022 SEMU Consulting BSD 3-Clause license\n"
+    + "https://github.com/semuconsulting/pygpsclient/\n\n"
+)

--- a/pygpsclient/settings_frame.py
+++ b/pygpsclient/settings_frame.py
@@ -165,7 +165,11 @@ class SettingsFrame(Frame):
 
         # serial port configuration panel
         self._frm_serial = SerialConfigFrame(
-            self, preselect=KNOWNGPS, timeouts=TIMEOUTS, bpsrates=BPSRATES
+            self,
+            preselect=KNOWNGPS,
+            timeouts=TIMEOUTS,
+            bpsrates=BPSRATES,
+            port=self.__app.user_port,  # user-defined serial port
         )
 
         # socket configuration panel

--- a/pygpsclient/strings.py
+++ b/pygpsclient/strings.py
@@ -111,6 +111,7 @@ LBLSERVERMODE = "Mode"
 LBLCFGDYN = "CFG-* Other Configuration"
 LBLGGALIVE = "Receiver"
 LBLGGAFIXED = "Fixed Reference"
+LBLUDPORT = "USER-DEFINED PORT"
 
 # Dialog text
 DLGUBXCONFIG = "UBX Configuration"


### PR DESCRIPTION
# PyGPSClient Pull Request Template

## Description

Add provision to pass user-defined serial port designator via command line keyword argument `port` or environment variable `PYGPSCLIENT_USERPORT`.

e.g.

```shell
pygpsclient port=/dev/tty12345
```
or
```shell
export PYGPSCLIENT_USERPORT = "/dev/tty12345"
pygpsclient
```

Any user-defined port will appear in the serial port listbox as the first preselected item.

Fixes #34

## Testing

Please test all changes, however trivial, against the supplied unittest suite `tests/test_*.py` e.g. by executing the `tests/testsuite.py` module or using your IDE's native Python unittest integration facilities. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [ ] Test A
- [ ] Test B

## Checklist:

- [x] My code follows the style guidelines of this project (see `CONTRIBUTING.MD`).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain >= 99% code coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [x] Any dependent changes have been merged and published in downstream modules.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.
