### PR TITLE
fix for IPV6 "Invalid Argument" error

### DIFF
--- a/src/pygpsclient/stream_handler.py
+++ b/src/pygpsclient/stream_handler.py
@@ -152,11 +152,9 @@ class StreamHandler:
                 soc = settings["socket_settings"]
                 server = soc.server.get()
                 port = int(soc.port.get())
-                flowinfo = int(soc.flowinfo.get())
-                scopeid = int(soc.scopeid.get())
                 if soc.protocol.get()[-4:] == "IPv6":
                     afam = socket.AF_INET6
-                    conn = (server, port, flowinfo, scopeid)
+                    conn = socket.getaddrinfo(server,port)[1][4]
                 else:  # IPv4
                     afam = socket.AF_INET
                     conn = (server, port)


### PR DESCRIPTION
# PyGPSClient Pull Request Template

## Description

Minor change for IPv6 socket connection. "Invalid Argument" error is thrown even when a valid IPv6 address e.g. fe80::1%eth0 is given in server field.

Fixes # (issue)

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [/] Test A

## Checklist:

- [/] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygpsclient/blob/master/CODE_OF_CONDUCT.md)).
- [/] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pygpsclient/blob/master/CONTRIBUTING.md)).
- [/] I have performed a self-review of my own code.
- [/] I have commented my code, particularly in hard-to-understand areas.
- [/] I have made corresponding changes to the documentation.
- [/] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain test coverage.
- [/] I have tested my code against the full `tests/test_*.py` unittest suite.
- [/] My changes generate no new warnings.
- [/] Any dependent changes have been merged and published in downstream modules.
- [/] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [/] I understand and acknowledge that the code will be published under a BSD 3-Clause license.