### PR TITLE
Send an empty datagram to estabilish connection to udp servers

### DIFF
--- a/src/pygpsclient/stream_handler.py
+++ b/src/pygpsclient/stream_handler.py
@@ -164,6 +164,8 @@ class StreamHandler:
                     socktype = socket.SOCK_STREAM
                 with socket.socket(afam, socktype) as stream:
                     stream.connect(conn)
+                    if socktype == socket.SOCK_DGRAM:
+                        stream.send(b"") # send empty datagram to establish connection
                     self._readloop(
                         stopevent,
                         stream,


### PR DESCRIPTION
# PyGPSClient Pull Request Template

## Description

This makes us send an empty datagram when connecting to an UDP server. This is required as UDP is a connectionless protocol, so the server can only start sending us data once we send it something to let it know we exist.

Fixes # (issue)

## Testing

Please test all changes, however trivial, against the supplied pytest suite `tests/test_*.py`. Please describe any test cases you have amended or added to this suite to maintain >= 99% code coverage.

- [x] Tested connecting to an M9N unit using [bridges](https://github.com/patrickelectric/bridges).

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygpsclient/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pygpsclient/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain test coverage.
- [ ] I have tested my code against the full `tests/test_*.py` unittest suite.
- [ ] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.