### PR TITLE
Fix type formatting issue

### DIFF
--- a/src/pygpsclient/banner_frame.py
+++ b/src/pygpsclient/banner_frame.py
@@ -48,6 +48,7 @@ from pygpsclient.globals import (
     UMK,
 )
 from pygpsclient.helpers import m2ft, ms2kmph, ms2knots, ms2mph, scale_font
+from pygpsclient.strings import NA
 
 DGPSYES = "YES"
 DGPSNO = "N/A"
@@ -529,22 +530,33 @@ class BannerFrame(Frame):
         :param str units: distance units as string (UMM, UMK, UI, UIK)
         """
 
-        pdop = self.__app.gnss_status.pdop
-        self._dop.set(f"{pdop:.2f} {dop2str(pdop):<9}")
-        self._hvdop.set(
-            f"hdop {self.__app.gnss_status.hdop:.2f}\n"
-            + f"vdop {self.__app.gnss_status.vdop:.2f}"
-        )
-        if units in (UI, UIK):
-            self._hvacc.set(
-                f"hacc {m2ft(self.__app.gnss_status.hacc):.3f}\n"
-                + f"vacc {m2ft(self.__app.gnss_status.vacc):.3f}"
+        try:
+            pdop = self.__app.gnss_status.pdop
+            self._dop.set(f"{pdop:.2f} {dop2str(pdop):<9}")
+        except (TypeError, ValueError):
+            self._dop.set(NA)
+
+        try:
+            self._hvdop.set(
+                f"hdop {self.__app.gnss_status.hdop:.2f}\n"
+                + f"vdop {self.__app.gnss_status.vdop:.2f}"
             )
-        else:
-            self._hvacc.set(
-                f"hacc {self.__app.gnss_status.hacc:.3f}\n"
-                + f"vacc {self.__app.gnss_status.vacc:.3f}"
-            )
+        except (TypeError, ValueError):
+            self._hvdop.set(f"hdop {NA}\nvdop {NA}")
+
+        try:
+            if units in (UI, UIK):
+                self._hvacc.set(
+                    f"hacc {m2ft(self.__app.gnss_status.hacc):.3f}\n"
+                    + f"vacc {m2ft(self.__app.gnss_status.vacc):.3f}"
+                )
+            else:
+                self._hvacc.set(
+                    f"hacc {self.__app.gnss_status.hacc:.3f}\n"
+                    + f"vacc {self.__app.gnss_status.vacc:.3f}"
+                )
+        except (TypeError, ValueError):
+            self._hvacc.set(f"hacc {NA}\nvacc {NA}")
 
     def _update_dgps(self, units):
         """


### PR DESCRIPTION
# PyGPSClient Pull Request Template

## Description
I noticed the `GraphviewFrame` was not updating until the receiver I was using got a fix. I also noticed some repeating traceback logs in the console like this:

```python
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.13/3.13.5/Frameworks/Python.framework/Versions/3.13/lib/python3.13/tkinter/__init__.py", line 2068, in __call__
    return self.func(*args)
           ~~~~~~~~~^^^^^^^
  File "/Users/dlascelles/pygpsclient/lib/python3.13/site-packages/pygpsclient/app.py", line 641, in on_gnss_read
    self.process_data(raw_data, parsed_data)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dlascelles/pygpsclient/lib/python3.13/site-packages/pygpsclient/app.py", line 854, in process_data
    self._refresh_widgets()
    ~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/dlascelles/pygpsclient/lib/python3.13/site-packages/pygpsclient/app.py", line 873, in _refresh_widgets
    self.frm_banner.update_frame()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/dlascelles/pygpsclient/lib/python3.13/site-packages/pygpsclient/banner_frame.py", line 408, in update_frame
    self._update_dop(units)
    ~~~~~~~~~~~~~~~~^^^^^^^
  File "/Users/dlascelles/pygpsclient/lib/python3.13/site-packages/pygpsclient/banner_frame.py", line 533, in _update_dop
    self._dop.set(f"{pdop:.2f} {dop2str(pdop):<9}")
                    ^^^^^^^^^^
ValueError: Unknown format code 'f' for object of type 'str'
```

After investigating, I noticed that when an incoming `NMEAMessage` has missing properties, it defaults to an empty `str`. When the `str` is attempted to be formatted as a `float`, this error occurs.

After fixing this with the suggested change, it also resolved the issue with the `GraphviewFrame` not updating, which I suspect was simply due to the `BannerFrame` update crashing that update iteration.

Fixes #202 

## Checklist:

- [x] I agree to abide by the code of conduct (see [CODE_OF_CONDUCT.md](https://github.com/semuconsulting/pygpsclient/blob/master/CODE_OF_CONDUCT.md)).
- [x] My code follows the style guidelines of this project (see [CONTRIBUTING.MD](https://github.com/semuconsulting/pygpsclient/blob/master/CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] (*if appropriate*) I have added test cases to the `tests/test_*.py` unittest suite to maintain test coverage.
- [x] I have tested my code against the full `tests/test_*.py` unittest suite.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
- [x] I have [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) my commits.
- [x] I understand and acknowledge that the code will be published under a BSD 3-Clause license.